### PR TITLE
Add backlog.com in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,11 +13,12 @@
     },
     "permissions": [
         "tabs",
+        "https://*.backlog.com/*",
         "https://*.backlog.jp/*"
     ],
     "content_scripts": [
         {
-            "matches": [ "https://*.backlog.jp/*" ],
+            "matches": [ "https://*.backlog.com/*", "https://*.backlog.jp/*" ],
             "js": [
                 "js/jquery-2.1.3.min.js",
                 "js/underscore-min.js",


### PR DESCRIPTION
Add backlog.com into manifest.json for Backlog service domains.
バックログサービスドメイン用に、backlog.comをmanifest.jsonに追加します。

See also:
  [Backlogはサービスのドメインを.comドメインに変更します！（API開発者様へ重要なお願い） | Backlogブログ](https://backlog.com/ja/blog/backlog-jp-change-domain-backlog-com/#backlog.com-schedule)